### PR TITLE
Add tilde symbol to require packages version numbers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.*",
-        "illuminate/validation": "4.*",
-        "giggsey/libphonenumber-for-php": "6.1.*"
+        "illuminate/support": "~4.0",
+        "illuminate/validation": "~4.0",
+        "giggsey/libphonenumber-for-php": "~6.0"
     },
     "suggest": {
         "monarobase/country-list": "Adds a compatible (and fully translated) country list API."


### PR DESCRIPTION
Add tilde instead of star, [read more](https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-operator).
