### PR TITLE
Fix include of helpers.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,10 @@
     "autoload": {
         "psr-0": {
             "Propaganistas\\LaravelPhone": "src/"
-        }
+        },
+        "files": [
+            "helpers.php"
+        ]        
     },
     "prefer-stable": true
 }

--- a/src/Propaganistas/LaravelPhone/LaravelPhoneServiceProvider.php
+++ b/src/Propaganistas/LaravelPhone/LaravelPhoneServiceProvider.php
@@ -19,8 +19,6 @@ class LaravelPhoneServiceProvider extends ServiceProvider
 	public function boot()
 	{
 		$this->app['validator']->extend('phone', 'Propaganistas\LaravelPhone\Validator@phone');
-
-        include __DIR__ . '/../../../helpers.php';
 	}
 
 	/**


### PR DESCRIPTION
This PR improves how `helpers.php` will be loaded. The way it's done at the moment will break any script where `LaravelPhoneServiceProvider::boot()` is executed more than once during runtime. (Notably tests with `phpunit` which refreshes the app container before each test.)

Alternatively, you may change `LaravelPhoneServiceProvider.php:23` to use `include_once` instead.