### PR TITLE
If multiple countries allowed, phone number validation performed against first country only.

### DIFF
--- a/src/PhoneValidator.php
+++ b/src/PhoneValidator.php
@@ -95,8 +95,13 @@ class PhoneValidator
                         return $phoneUtil->isValidNumber($phoneProto);
                     }
 
-                    // Force validation of number against the specified country.
-                    return $phoneUtil->isValidNumberForRegion($phoneProto, $country);
+                    // Validate number against the specified country.  Return only if success.
+                    // If failure, continue loop to next specfied country
+                    $success = $phoneUtil->isValidNumberForRegion($phoneProto, $country);
+
+                    if ($success) {
+                        return true;
+                    }
                 }
 
             } catch (NumberParseException $e) {
@@ -104,6 +109,7 @@ class PhoneValidator
             }
         }
 
+        // All specified country validations have failed.
         return false;
     }
 

--- a/tests/TestPhoneValidator.php
+++ b/tests/TestPhoneValidator.php
@@ -46,6 +46,9 @@ class PhoneValidatorTest extends PHPUnit_Framework_TestCase {
 		// Validator with multiple country values, one correct.
 		$this->assertTrue($this->performValidation(['value' => '016123456', 'params' => 'BE,NL']));
 
+                // Validator with multiple country values, value correct for second country in list.
+                $this->assertTrue($this->performValidation(['value' => '016123456', 'params' => 'NL,BE']));
+
 		// Validator with multiple wrong country values.
 		$this->assertFalse($this->performValidation(['value' => '016123456', 'params' => 'DE,NL']));
 	}


### PR DESCRIPTION
There is a bug in the phone validation for multiple countries.  When multiple countries are allowed, the phone number is validated against the first country and returns invalid if the phone number is not valid for the first country being tested.  The other countries are never tested.

There is a catch-all return false at the end of the loop, which should execute if all country validations fail.  I updated the logic so that the validation returns true if the phone number validates successfully against the current country in the loop.  If not, the loop continues to execute until either the phone number validates successfully against a country in the array, or all countries have been exhausted, in which case the fall-back existing return false will return.

The unit tests have also been updated to test this scenario; the exiting unit test to test for multiple countries passes because the country the test number is valid for happens to be the first country in the array.