### PR TITLE
Add a Laravel Facade to expose the PhoneNumberUtil instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ In your app config, add the Service Provider to the `$providers` array
     ...
     Propaganistas\LaravelPhone\LaravelPhoneServiceProvider::class,
 ],
+
+'aliases' => [
+    ...
+    'Phone' => Propaganistas\LaravelPhone\LaravelPhoneFacade::class
+]
 ```
 
 In your languages directory, add for each language an extra language line for the validator:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
     <testsuites>
         <testsuite name="Package Test Suite">
             <file>./tests/Laravel5.php</file>
+            <file>./tests/FacadeTest.php</file>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/LaravelPhoneFacade.php
+++ b/src/LaravelPhoneFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Propaganistas\LaravelPhone;
+
+/**
+ * Class LaravelPhoneFacade
+ * @package Propaganistas\LaravelPhone
+ */
+class LaravelPhoneFacade extends \Illuminate\Support\Facades\Facade
+{
+    /**
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'libphonenumber';
+    }
+}

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Propaganistas\LaravelPhone\Tests;
+
+use libphonenumber\PhoneNumber;
+
+class FacadeTest extends Laravel5
+{
+    public function testParseMethod()
+    {
+        $phoneNumber = \Phone::parse('650-429-2057', 'US');
+        $this->assertTrue($phoneNumber instanceof PhoneNumber);
+    }
+}

--- a/tests/Laravel5.php
+++ b/tests/Laravel5.php
@@ -1,10 +1,27 @@
 <?php namespace Propaganistas\LaravelPhone\Tests;
 
+use Propaganistas\LaravelPhone\LaravelPhoneFacade;
+
 class Laravel5 extends PhoneValidatorTest
 {
 
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return array
+     */
 	protected function getPackageProviders($app)
 	{
 		return ['Propaganistas\LaravelPhone\LaravelPhoneServiceProvider'];
 	}
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return array
+     */
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Phone' => LaravelPhoneFacade::class,
+        ];
+    }
 }


### PR DESCRIPTION
`PhoneNumberUtil` class has a lot of interesting methods to be used. We include here a Facade to the registered singleton `libphonenumber`, exposing `PhoneNumberUtil` methods, like `parse()`, `isValidNumber()`, etc.

This Facade allows us to include an alias like `Phone`, for example, using those methods in the Laravel way: `Phone::parse()`, `Phone::isValidNumber()`.

Thanks!