### PR TITLE
Upgrade to libphonenumber-for-php v8.0 and fix phpunit warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^2.0|^3.0",
-        "phpunit/phpunit": "^4.0|^5.2"
+        "phpunit/phpunit": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         "php": ">=5.4.0",
         "illuminate/support": "^4.0|^5.0",
         "illuminate/validation": "^4.0|^5.0",
-        "giggsey/libphonenumber-for-php": "^8.0",
+        "giggsey/libphonenumber-for-php": "^7.0|^8.0",
         "julien-c/iso3166": "^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^2.0|^3.0",
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "^4.0|^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "^4.0|^5.0",
         "illuminate/validation": "^4.0|^5.0",
-        "giggsey/libphonenumber-for-php": "^7.0",
+        "giggsey/libphonenumber-for-php": "^8.0",
         "julien-c/iso3166": "^2.0"
     },
     "require-dev": {

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -254,7 +254,7 @@ class PhoneValidatorTest extends TestCase
 
     public function testValidatePhoneNoDefaultCountryNoCountryField()
     {
-        $this->setExpectedException('Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException');
+        $this->expectException('Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException');
 
         // Validator with no country field or given country.
         $this->performValidation([
@@ -347,7 +347,7 @@ class PhoneValidatorTest extends TestCase
 
     public function testValidatePhoneFaultyParameters()
     {
-        $this->setExpectedException('Propaganistas\LaravelPhone\Exceptions\InvalidParameterException');
+        $this->expectException('Propaganistas\LaravelPhone\Exceptions\InvalidParameterException');
 
         // Validator with given country, correct type, faulty parameter.
         $this->performValidation([

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -252,10 +252,11 @@ class PhoneValidatorTest extends TestCase
         ]));
     }
 
+    /**
+     * @expectedException \Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException
+     */
     public function testValidatePhoneNoDefaultCountryNoCountryField()
     {
-        $this->expectException('Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException');
-
         // Validator with no country field or given country.
         $this->performValidation([
             'field' => '016123456',
@@ -345,10 +346,11 @@ class PhoneValidatorTest extends TestCase
         ]));
     }
 
+    /**
+     * @expectedException \Propaganistas\LaravelPhone\Exceptions\InvalidParameterException
+     */
     public function testValidatePhoneFaultyParameters()
     {
-        $this->expectException('Propaganistas\LaravelPhone\Exceptions\InvalidParameterException');
-
         // Validator with given country, correct type, faulty parameter.
         $this->performValidation([
             'field' => '016123456',

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -11,14 +11,14 @@ class PhoneValidatorTest extends TestCase
 
     protected $validator;
 
-    protected function getPackageProviders($app)
+    protected function getPackageProviders()
     {
         return [
             'Propaganistas\LaravelPhone\LaravelPhoneServiceProvider',
         ];
     }
 
-    protected function getPackageAliases($app)
+    protected function getPackageAliases()
     {
         return [
             'Phone' => 'Propaganistas\LaravelPhone\LaravelPhoneFacade',
@@ -252,11 +252,10 @@ class PhoneValidatorTest extends TestCase
         ]));
     }
 
-    /**
-     * @expectedException \Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException
-     */
     public function testValidatePhoneNoDefaultCountryNoCountryField()
     {
+        $this->setExpectedException('Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException');
+
         // Validator with no country field or given country.
         $this->performValidation([
             'field' => '016123456',
@@ -346,11 +345,10 @@ class PhoneValidatorTest extends TestCase
         ]));
     }
 
-    /**
-     * @expectedException \Propaganistas\LaravelPhone\Exceptions\InvalidParameterException
-     */
     public function testValidatePhoneFaultyParameters()
     {
+        $this->setExpectedException('Propaganistas\LaravelPhone\Exceptions\InvalidParameterException');
+
         // Validator with given country, correct type, faulty parameter.
         $this->performValidation([
             'field' => '016123456',

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -11,14 +11,14 @@ class PhoneValidatorTest extends TestCase
 
     protected $validator;
 
-    protected function getPackageProviders()
+    protected function getPackageProviders($app)
     {
         return [
             'Propaganistas\LaravelPhone\LaravelPhoneServiceProvider',
         ];
     }
 
-    protected function getPackageAliases()
+    protected function getPackageAliases($app)
     {
         return [
             'Phone' => 'Propaganistas\LaravelPhone\LaravelPhoneFacade',
@@ -254,7 +254,7 @@ class PhoneValidatorTest extends TestCase
 
     public function testValidatePhoneNoDefaultCountryNoCountryField()
     {
-        $this->setExpectedException('Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException');
+        $this->expectException('Propaganistas\LaravelPhone\Exceptions\NoValidCountryFoundException');
 
         // Validator with no country field or given country.
         $this->performValidation([
@@ -347,7 +347,7 @@ class PhoneValidatorTest extends TestCase
 
     public function testValidatePhoneFaultyParameters()
     {
-        $this->setExpectedException('Propaganistas\LaravelPhone\Exceptions\InvalidParameterException');
+        $this->expectException('Propaganistas\LaravelPhone\Exceptions\InvalidParameterException');
 
         // Validator with given country, correct type, faulty parameter.
         $this->performValidation([


### PR DESCRIPTION
This upgrades libphonenumber-for-php to the latest version and I also noticed some fixes to the test cases were needed.