### PR TITLE
Correcting dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "illuminate/support": "5.0||5.1||5.2||5.3||5.4||5.5",
-        "illuminate/validation": "5.0||5.1||5.2||5.3||5.4||5.5",
+        "illuminate/support": "^5.0, <5.6"
+        "illuminate/validation": "5.0, <5.6",
         "giggsey/libphonenumber-for-php": "^7.0|^8.0",
         "julien-c/iso3166": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "illuminate/support": "^5.0",
-        "illuminate/validation": "^5.0",
+        "illuminate/support": "5.0||5.1||5.2||5.3||5.4||5.5",
+        "illuminate/validation": "5.0||5.1||5.2||5.3||5.4||5.5",
         "giggsey/libphonenumber-for-php": "^7.0|^8.0",
         "julien-c/iso3166": "^2.0"
     },


### PR DESCRIPTION
Laravel & its components do not follow semver. So having `^5.0` would mean that it can fetch 5.0 to 5.9... even though these may break your package in future. 