### PR TITLE
Adding a PhoneNumberException interface to encapsulate all the exceptions

### DIFF
--- a/src/Exceptions/CountryCodeException.php
+++ b/src/Exceptions/CountryCodeException.php
@@ -1,6 +1,8 @@
 <?php namespace Propaganistas\LaravelPhone\Exceptions;
 
-class CountryCodeException extends \Exception
+use Exception;
+
+class CountryCodeException extends Exception implements PhoneNumberException
 {
     /**
      * Invalid country code static constructor.

--- a/src/Exceptions/InvalidParameterException.php
+++ b/src/Exceptions/InvalidParameterException.php
@@ -1,8 +1,9 @@
 <?php namespace Propaganistas\LaravelPhone\Exceptions;
 
+use Exception;
 use Illuminate\Support\Collection;
 
-class InvalidParameterException extends \Exception
+class InvalidParameterException extends Exception implements PhoneNumberException
 {
     /**
      * Ambiguous parameter static constructor.

--- a/src/Exceptions/NumberFormatException.php
+++ b/src/Exceptions/NumberFormatException.php
@@ -1,6 +1,8 @@
 <?php namespace Propaganistas\LaravelPhone\Exceptions;
 
-class NumberFormatException extends \Exception
+use Exception;
+
+class NumberFormatException extends Exception implements PhoneNumberException
 {
     /**
      * Invalid number format static constructor.

--- a/src/Exceptions/NumberParseException.php
+++ b/src/Exceptions/NumberParseException.php
@@ -1,8 +1,9 @@
 <?php namespace Propaganistas\LaravelPhone\Exceptions;
 
+use Exception;
 use libphonenumber\NumberParseException as libNumberParseException;
 
-class NumberParseException extends libNumberParseException
+class NumberParseException extends Exception implements PhoneNumberException
 {
     /**
      * Country specification required static constructor.

--- a/src/Exceptions/PhoneNumberException.php
+++ b/src/Exceptions/PhoneNumberException.php
@@ -1,0 +1,6 @@
+<?php namespace Propaganistas\LaravelPhone\Exceptions;
+
+/** 
+* Marker interface for all the exceptions in this package.
+*/
+interface PhoneNumberException {}


### PR DESCRIPTION
The idea in here is to be able to catch all the exceptions, like this:

```
try {

# Laravel-Phone calls

} catch( PhoneNumberException $e) {
    return Redirect::back()->withErrors(['Please, review the phone number!'])->withInput();
}
```