### PR TITLE
adding custom casts implemented in Laravel 7.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=7.1",
         "illuminate/support": "^6.0|^7.0",
         "illuminate/validation": "^6.0|^7.0",
+        "illuminate/contracts": "^7.0",
         "giggsey/libphonenumber-for-php": "^7.0|^8.0",
         "league/iso3166": "^2.0"
     },

--- a/src/Casts/Phone.php
+++ b/src/Casts/Phone.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace  Propaganistas\LaravelPhone\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Propaganistas\LaravelPhone\PhoneNumber;
+
+
+class Phone implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return PhoneNumber
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return  PhoneNumber::make($value);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  string  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return (string) PhoneNumber::make($value);
+    }
+}


### PR DESCRIPTION
now you can use

```
protected $casts = [
    'phone-number' => Phone::class
];
```
on your model for Laravel 7.x