### PR TITLE
Update typehints in phpdoc

### DIFF
--- a/src/Exceptions/NumberParseException.php
+++ b/src/Exceptions/NumberParseException.php
@@ -37,7 +37,7 @@ class NumberParseException extends libNumberParseException
      * Country mismatch static constructor.
      *
      * @param string $number
-     * @param string|array $country
+     * @param string|array $countries
      * @return static
      */
     public static function countryMismatch($number, $countries)

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -145,7 +145,7 @@ class PhoneNumber implements Jsonable, JsonSerializable, Serializable
     /**
      * Format the phone number in a given format.
      *
-     * @param string $format
+     * @param string|int $format
      * @return string
      * @throws \Propaganistas\LaravelPhone\Exceptions\NumberFormatException
      */

--- a/src/Rules/Phone.php
+++ b/src/Rules/Phone.php
@@ -74,7 +74,7 @@ class Phone
     /**
      * Set the phone types.
      *
-     * @param string|array $type
+     * @param int|string|array $type
      * @return $this
      */
     public function type($type)

--- a/src/Traits/ParsesFormats.php
+++ b/src/Traits/ParsesFormats.php
@@ -27,8 +27,8 @@ trait ParsesFormats
     /**
      * Parse a phone format.
      *
-     * @param string $format
-     * @return string|null
+     * @param int|string $format
+     * @return int|null
      */
     protected static function parseFormat($format)
     {

--- a/src/Traits/ParsesFormats.php
+++ b/src/Traits/ParsesFormats.php
@@ -28,7 +28,7 @@ trait ParsesFormats
      * Parse a phone format.
      *
      * @param string $format
-     * @return string
+     * @return string|null
      */
     protected static function parseFormat($format)
     {

--- a/src/Traits/ParsesTypes.php
+++ b/src/Traits/ParsesTypes.php
@@ -17,7 +17,7 @@ trait ParsesTypes
     /**
      * Determine whether the given type is valid.
      *
-     * @param string $type
+     * @param int|string $type
      * @return bool
      */
     public static function isValidType($type)
@@ -28,7 +28,7 @@ trait ParsesTypes
     /**
      * Parse a phone type into constant's value.
      *
-     * @param string|array $types
+     * @param int|string|array $types
      * @return array
      */
     protected static function parseTypes($types)
@@ -53,7 +53,7 @@ trait ParsesTypes
     /**
      * Parse a phone type into its string representation.
      *
-     * @param string|array $types
+     * @param int|string|array $types
      * @return array
      */
     protected static function parseTypesAsStrings($types)


### PR DESCRIPTION
Hi,

Static code check was complaining in my app that the third argument to the helper `phone()` couldn't be an int. I went ahead and updated some of the phpdoc types.

If you are interested, I can create a new PR where I add phpstan to the CI-checks.