### PR TITLE
improved lenient parsing of phone numbers

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -262,10 +262,11 @@ class PhoneNumber implements Jsonable, JsonSerializable, Serializable
             $countries[] = null;
         }
 
+        $validNumberMethod = $this->lenient ? 'isPossibleNumber' : 'isValidNumber';
         foreach ($countries as $country) {
             $instance = $this->lib->parse($this->number, $country);
 
-            if ($this->lib->isValidNumber($instance)) {
+            if ($this->lib->$validNumberMethod($instance)) {
                 return $this->lib->getRegionCodeForNumber($instance);
             }
         }

--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -409,4 +409,19 @@ class PhoneNumberTest extends TestCase
 
         $this->assertEquals('BE', $object->getCountry());
     }
+
+    /** @test */
+    public function it_formats_lenient_number_with_country_code_detection()
+    {
+        $this->assertEquals('+491244614038', PhoneNumber::make('+49(0)12-44 614038')
+            ->lenient()
+            ->formatE164());
+    }
+
+    /** @test */
+    public function it_throws_exception_on_not_valid_phone_with_country_code_detection()
+    {
+        $this->expectException(NumberParseException::class);
+        PhoneNumber::make('+49(0)12-44 614038')->formatE164();
+    }
 }

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -354,6 +354,18 @@ class PhoneValidatorTest extends TestCase
             ['field' => '5550123'],
             ['field' => 'phone:LENIENT,US'])->passes()
         );
+
+        // Validator with possible German phone, lenient on
+        $this->assertTrue($this->validator->make(
+            ['field' => '+49(0)12-44 614038'],
+            ['field' => 'phone:LENIENT'])->passes()
+        );
+
+        // Validator with possible German phone, lenient off
+        $this->assertFalse($this->validator->make(
+            ['field' => '+49(0)12-44 614038'],
+            ['field' => 'phone'])->passes()
+        );
     }
 
     /** @test */
@@ -570,7 +582,7 @@ class PhoneValidatorTest extends TestCase
             ['field' => 'phone:mobile,country_code'])->passes()
         );
     }
-    
+
     /** @test */
     public function it_copes_with_nullable_validation_rule()
     {


### PR DESCRIPTION
When using with Laravel validation, a lenient validation was rejecting possible numbers with country code. Also I could not parse such a number in lenient mode. This PR adds a missing check for lenient mode when validating a number.