### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/src/Casts/PhoneNumberCast.php
+++ b/src/Casts/PhoneNumberCast.php
@@ -34,7 +34,7 @@ abstract class PhoneNumberCast implements CastsAttributes, SerializesCastableAtt
         // Discover if an attribute was provided. If not, default to _country.
         $inputField = Collection::make($parameters)
             ->intersect(array_keys(Arr::dot($attributes)))
-            ->first() ?: "${key}_country";
+            ->first() ?: "{$key}_country";
 
         // Attempt to retrieve the field's value.
         if ($inputCountry = Arr::get($attributes, $inputField)) {

--- a/src/Validation/Phone.php
+++ b/src/Validation/Phone.php
@@ -107,7 +107,7 @@ class Phone
         // Discover if an input field was provided. If not, guess the field's name.
         $inputField = Collection::make($parameters)
                                 ->intersect(array_keys(Arr::dot($data)))
-                                ->first() ?: "${attribute}_country";
+                                ->first() ?: "{$attribute}_country";
 
         // Attempt to retrieve the field's value.
         if ($inputCountry = Arr::get($data, $inputField)) {


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes all two of such occurrence in `Propaganistas/Laravel-Phone` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)