### PR TITLE
Use callAfterResolving

### DIFF
--- a/src/PhoneServiceProvider.php
+++ b/src/PhoneServiceProvider.php
@@ -24,7 +24,7 @@ class PhoneServiceProvider extends ServiceProvider
 
         $this->app->alias('libphonenumber', PhoneNumberUtil::class);
 
-        $this->app->afterResolving('validator', static function (Factory $validator) {
+        $this->callAfterResolving('validator', static function (Factory $validator) {
             $validator->extendDependent('phone', Validation\Phone::class . '@validate');
         });
 


### PR DESCRIPTION
This PR fixes a subtle issue introduced with https://github.com/Propaganistas/Laravel-Phone/pull/202.

The custom `phone` validator registration will not happen if the application registers `ServiceProvider`s lazily: after the framework has booted and the validator instance has been resolved.

`callAfterResolving` does an additional check to see if the service binding has been resolved already.

Thanks!