### PR TITLE
🐛  Fix validate one-digit phone

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -377,15 +377,17 @@ class PhoneNumber implements Jsonable, JsonSerializable, Serializable
      */
     public function numberLooksInternational()
     {
-        if (empty($this->number) || strlen($this->number) < 2) {
+        preg_match('/([a-z]{2})?(\+.+)/i', $this->number, $matches);
+        
+        if (empty($matches)) {
             return false;
         }
-
-        if (Str::startsWith($this->number, '+')) {
-            return true;
+        
+        if ($matches[1]) {
+            return static::isValidCountryCode(Str::substr($this->number, 0, 2))
         }
 
-        return strpos($this->number, '+', 2) && static::isValidCountryCode(Str::substr($this->number, 0, 2));
+        return true;
     }
 
     /**

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -377,7 +377,7 @@ class PhoneNumber implements Jsonable, JsonSerializable, Serializable
      */
     public function numberLooksInternational()
     {
-        if (empty($this->number)) {
+        if (empty($this->number) || strlen($this->number) < 2) {
             return false;
         }
 

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -384,7 +384,7 @@ class PhoneNumber implements Jsonable, JsonSerializable, Serializable
         }
         
         if ($matches[1]) {
-            return static::isValidCountryCode(Str::substr($this->number, 0, 2))
+            return static::isValidCountryCode(Str::substr($this->number, 0, 2));
         }
 
         return true;

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -626,4 +626,13 @@ class PhoneValidatorTest extends TestCase
             ['field' => ['phone:AC']]
         )->passes());
     }
+
+    /** @test */
+    public function it_validates_one_digit_phone()
+    {
+        $this->assertFalse($this->validator->make(
+            ['field' => '1'],
+            ['field' => 'phone:AUTO'])->passes()
+        );
+    }
 }

--- a/tests/PhoneValidatorTest.php
+++ b/tests/PhoneValidatorTest.php
@@ -628,7 +628,7 @@ class PhoneValidatorTest extends TestCase
     }
 
     /** @test */
-    public function it_validates_one_digit_phone()
+    public function it_doesnt_throw_for_one_digit_numbers()
     {
         $this->assertFalse($this->validator->make(
             ['field' => '1'],


### PR DESCRIPTION
Hi there, this is an issue that when validating a one-digit phone number gits the error below:
```
PHP Warning:  strpos(): Offset not contained in string in /Users/xxxxx/vendor/propaganistas/laravel-phone/src/PhoneNumber.php on line 388
```


please make a new release on 4x, we have a huge project facing this issue.

Thanks 
Ibrahim Hassan