### PR TITLE
Sync validation translation with Laravel's "must" convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Service Provider gets discovered automatically by Laravel.
 In your languages directory, add an extra translation in every `validation.php` language file:
 
 ```php
-'phone' => 'The :attribute field contains an invalid number.',
+'phone' => 'The :attribute field must be a valid number.',
 ```
 
 ## Validation


### PR DESCRIPTION
This PR is related to the validation translation convention set in https://github.com/laravel/framework/pull/45989.

It updates the validation translation in `README.md` to conform to that convention.