### PR TITLE
Fix: RawPhoneNumberCast, Brazilian Numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /vendor
 /.idea
+.run
+.DS_Store
 composer.phar
 composer.lock
 .phpunit.result.cache

--- a/src/Casts/RawPhoneNumberCast.php
+++ b/src/Casts/RawPhoneNumberCast.php
@@ -14,12 +14,12 @@ class RawPhoneNumberCast extends PhoneNumberCast
         }
 
         $phone = new PhoneNumber($value,
-            $this->getPossibleCountries($key, $attributes)
+            $countries = $this->getPossibleCountries($key, $attributes)
         );
 
-        $country = $phone->getCountry();
+        $country = $phone->getCountry() ?? $countries;
 
-        if ($country === null) {
+        if (empty($country)) {
             throw new InvalidArgumentException('Missing country specification for '.$key.' attribute cast');
         }
 

--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -17,21 +17,21 @@ class PhoneNumberTest extends TestCase
         $object = new PhoneNumber('012345678');
         $this->assertInstanceOf(PhoneNumber::class, $object);
     }
-    
+
     /** @test */
     public function it_constructs_with_string_country()
     {
         $object = new PhoneNumber('012345678', 'BE');
         $this->assertInstanceOf(PhoneNumber::class, $object);
     }
-    
+
     /** @test */
     public function it_constructs_with_array_country()
     {
         $object = new PhoneNumber('012345678', ['BE', 'NL']);
         $this->assertInstanceOf(PhoneNumber::class, $object);
     }
-    
+
     /** @test */
     public function it_constructs_with_null_country()
     {
@@ -485,7 +485,7 @@ class PhoneNumberTest extends TestCase
         $this->assertTrue($object->notEquals('1234'));
         $this->assertTrue($object->notEquals('012345678', 'NL'));
     }
-    
+
     /** @test */
     public function helper_function_constructs_without_country()
     {
@@ -493,7 +493,7 @@ class PhoneNumberTest extends TestCase
         $expected = new PhoneNumber('+32 12 34 56 78');
         $this->assertEquals($expected, $actual);
     }
-    
+
     /** @test */
     public function helper_function_constructs_with_string_country()
     {
@@ -501,7 +501,7 @@ class PhoneNumberTest extends TestCase
         $expected = new PhoneNumber('012 34 56 78', 'BE');
         $this->assertEquals($expected, $actual);
     }
-    
+
     /** @test */
     public function helper_function_constructs_with_array_country()
     {
@@ -509,7 +509,7 @@ class PhoneNumberTest extends TestCase
         $expected = new PhoneNumber('012 34 56 78', ['BE', 'NL']);
         $this->assertEquals($expected, $actual);
     }
-    
+
     /** @test */
     public function helper_function_constructs_with_null_country()
     {
@@ -517,7 +517,7 @@ class PhoneNumberTest extends TestCase
         $expected = new PhoneNumber('+32 12 34 56 78', null);
         $this->assertEquals($expected, $actual);
     }
-    
+
     /** @test */
     public function helper_function_formats()
     {

--- a/tests/RawPhoneNumberCastTest.php
+++ b/tests/RawPhoneNumberCastTest.php
@@ -106,7 +106,11 @@ class RawPhoneNumberCastTest extends TestCase
     private function phoneDataProvider(): array
     {
         return [
-            'BR' => ['BE', '012 34 56 78'],
+            'BE' => ['BE', '012 34 56 78'],
+            'US' => ['US', '012-34-56-78'],
+            'US incomplete' => ['US', '012-34'],
+            'NL' => ['NL', '020 7308544'],
+            'NL incomplete' => ['NL', '020 730'],
             'BR complete' => ['BR', '11987654321'],
             'BR incomplete' => ['BR', '1191234'],
             'BR incomplete with symbols' => ['BR', '(11) 91234'],

--- a/tests/RawPhoneNumberCastTest.php
+++ b/tests/RawPhoneNumberCastTest.php
@@ -40,25 +40,33 @@ class RawPhoneNumberCastTest extends TestCase
         $this->assertEquals(PhoneNumber::class, get_class($model->phone));
     }
 
-    /** @test */
-    public function it_gets_with_implicit_country_field()
+    /**
+     * @test
+     *
+     * @dataProvider phoneDataProvider
+     */
+    public function it_gets_with_implicit_country_field(string $country, string $phone)
     {
         $model = new ModelWithIncompleteRawCast;
         $model->setRawAttributes([
-            'phone_country' => 'BE',
-            'phone' => '012 34 56 78',
+            'phone_country' => $country,
+            'phone' => $phone,
         ]);
         $this->assertIsObject($model->phone);
         $this->assertEquals(PhoneNumber::class, get_class($model->phone));
     }
 
-    /** @test */
-    public function it_gets_with_explicit_country_field()
+    /**
+     * @test
+     *
+     * @dataProvider phoneDataProvider
+     */
+    public function it_gets_with_explicit_country_field(string $country, string $phone)
     {
         $model = new ModelWithRawCastAndCountryField;
         $model->setRawAttributes([
-            'country' => 'BE',
-            'phone' => '012 34 56 78',
+            'country' => $country,
+            'phone' => $phone,
         ]);
         $this->assertIsObject($model->phone);
         $this->assertEquals(PhoneNumber::class, get_class($model->phone));
@@ -94,12 +102,22 @@ class RawPhoneNumberCastTest extends TestCase
         $model->phone = null;
         $this->assertEquals(null, $model->toArray()['phone']);
     }
+
+    private function phoneDataProvider(): array
+    {
+        return [
+            'BR' => ['BE', '012 34 56 78'],
+            'BR complete' => ['BR', '11987654321'],
+            'BR incomplete' => ['BR', '1191234'],
+            'BR with symbols' => ['BR', '(11) 91234'],
+        ];
+    }
 }
 
 class ModelWithRawCast extends Model
 {
     protected $casts = [
-        'phone' => RawPhoneNumberCast::class.':BE,NL',
+        'phone' => RawPhoneNumberCast::class.':BE,NL,BR',
     ];
 }
 

--- a/tests/RawPhoneNumberCastTest.php
+++ b/tests/RawPhoneNumberCastTest.php
@@ -109,7 +109,7 @@ class RawPhoneNumberCastTest extends TestCase
             'BR' => ['BE', '012 34 56 78'],
             'BR complete' => ['BR', '11987654321'],
             'BR incomplete' => ['BR', '1191234'],
-            'BR with symbols' => ['BR', '(11) 91234'],
+            'BR incomplete with symbols' => ['BR', '(11) 91234'],
         ];
     }
 }


### PR DESCRIPTION
## What:

This PR is linked with issue: https://github.com/Propaganistas/Laravel-Phone/issues/224

## Why

After updating an application of mine to Laravel V10 I noticed that phone validation has stop to working when the value of the phone is something like: `(11) 91234` - Brazilian phone. After a few hours I realized that `getPossibleCountries` can find the correct country but `$phone->getCountry()` cannot. So I prepared a fix that is based on a double check. I was not able to understand the real reason to the error, but the code of this PR was able to run the test successful.

## Tests

I've created tests to validate the format of Brazilian phone numbers using values such as:
- (11) 91234
- 1191234
- 11987654321

**Note:** A data provider has been created and linked with two methods of `RawPhoneNumberCastTest`