### PR TITLE
Phone number to carrier mapper

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -10,6 +10,7 @@ use JsonSerializable;
 use libphonenumber\NumberParseException as libNumberParseException;
 use libphonenumber\PhoneNumberFormat as libPhoneNumberFormat;
 use libphonenumber\PhoneNumberType as libPhoneNumberType;
+use libphonenumber\PhoneNumberToCarrierMapper as libPhoneNumberToCarrierMapper;
 use libphonenumber\PhoneNumberUtil;
 use Propaganistas\LaravelPhone\Aspects\PhoneNumberCountry;
 use Propaganistas\LaravelPhone\Aspects\PhoneNumberFormat;
@@ -34,6 +35,15 @@ class PhoneNumber implements Jsonable, JsonSerializable
         $this->countries = Arr::wrap($country);
     }
 
+    public function getCarrier(): string|null
+    {
+        
+        $phoneUtil = PhoneNumberUtil::getInstance()->parse($this->number, $this->getCountry());
+        $carrierMapper = PhoneNumberToCarrierMapper::getInstance();
+        return $carrierMapper->getNameForNumber($phoneUtil, "en");
+    }
+
+    
     public function getCountry(): string|null
     {
         // Try to detect the country first from the number itself.
@@ -247,4 +257,12 @@ class PhoneNumber implements Jsonable, JsonSerializable
             return (string) $this->number;
         }
     }
+    
+    public function getCarrier(): string|null
+    {
+        $phoneUtil = PhoneNumberUtil::getInstance()->parse($this->number, $this->getCountry());
+        $carrierMapper = libPhoneNumberToCarrierMapper::getInstance();
+        return $carrierMapper->getNameForNumber($phoneUtil, "en");
+    }
+
 }

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -34,15 +34,6 @@ class PhoneNumber implements Jsonable, JsonSerializable
         $this->number = $number;
         $this->countries = Arr::wrap($country);
     }
-
-    public function getCarrier(): string|null
-    {
-        
-        $phoneUtil = PhoneNumberUtil::getInstance()->parse($this->number, $this->getCountry());
-        $carrierMapper = PhoneNumberToCarrierMapper::getInstance();
-        return $carrierMapper->getNameForNumber($phoneUtil, "en");
-    }
-
     
     public function getCountry(): string|null
     {


### PR DESCRIPTION
Adding following function to getCarrier (original carrier) from Google API.

```php
    public function getCarrier(): string|null
    {
        $phoneUtil = PhoneNumberUtil::getInstance()->parse($this->number, $this->getCountry());
        $carrierMapper = libPhoneNumberToCarrierMapper::getInstance();
        return $carrierMapper->getNameForNumber($phoneUtil, "en");
    }
```