### PR TITLE
Allow rejecting certain phone number types

### DIFF
--- a/src/Exceptions/IncompatibleTypesException.php
+++ b/src/Exceptions/IncompatibleTypesException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Propaganistas\LaravelPhone\Exceptions;
+
+class IncompatibleTypesException extends \Exception
+{
+    public static function invalid()
+    {
+        return new static('Cannot use type and notType at the same time.');
+    }
+}

--- a/src/Rules/Phone.php
+++ b/src/Rules/Phone.php
@@ -10,6 +10,7 @@ use libphonenumber\PhoneNumberType as libPhoneNumberType;
 use Propaganistas\LaravelPhone\Aspects\PhoneNumberCountry;
 use Propaganistas\LaravelPhone\Aspects\PhoneNumberType;
 use Propaganistas\LaravelPhone\Exceptions\NumberParseException;
+use Propaganistas\LaravelPhone\Exceptions\IncompatibleTypesException;
 use Propaganistas\LaravelPhone\PhoneNumber;
 
 class Phone implements Rule, ValidatorAwareRule
@@ -44,6 +45,10 @@ class Phone implements Rule, ValidatorAwareRule
             // Is the country within the allowed list (if applicable)?
             if (! $this->international && ! empty($countries) && ! $phone->isOfCountry($countries)) {
                 return false;
+            }
+
+            if (! empty($allowedTypes) && ! empty($blockedTypes)) {
+                throw IncompatibleTypesException::invalid();
             }
 
             // Is the type within the allowed list (if applicable)?

--- a/src/Rules/Phone.php
+++ b/src/Rules/Phone.php
@@ -20,7 +20,9 @@ class Phone implements Rule, ValidatorAwareRule
 
     protected array $countries = [];
 
-    protected array $types = [];
+    protected array $allowedTypes = [];
+
+    protected array $blockedTypes = [];
 
     protected bool $international = false;
 
@@ -33,7 +35,8 @@ class Phone implements Rule, ValidatorAwareRule
             ...$this->countries,
         ]);
 
-        $types = PhoneNumberType::sanitize($this->types);
+        $allowedTypes = PhoneNumberType::sanitize($this->allowedTypes);
+        $blockedTypes = PhoneNumberType::sanitize($this->blockedTypes);
 
         try {
             $phone = (new PhoneNumber($value, $countries))->lenient($this->lenient);
@@ -44,7 +47,12 @@ class Phone implements Rule, ValidatorAwareRule
             }
 
             // Is the type within the allowed list (if applicable)?
-            if (! empty($types) && ! $phone->isOfType($types)) {
+            if (! empty($allowedTypes) && ! $phone->isOfType($allowedTypes)) {
+                return false;
+            }
+
+            // Is the type within the blocked list (if applicable)?
+            if (! empty($blockedTypes) && $phone->isOfType($blockedTypes)) {
                 return false;
             }
 
@@ -74,7 +82,16 @@ class Phone implements Rule, ValidatorAwareRule
     {
         $types = is_array($type) ? $type : func_get_args();
 
-        $this->types = array_merge($this->types, $types);
+        $this->allowedTypes = array_merge($this->allowedTypes, $types);
+
+        return $this;
+    }
+
+    public function notType($type)
+    {
+        $types = is_array($type) ? $type : func_get_args();
+
+        $this->blockedTypes = array_merge($this->blockedTypes, $types);
 
         return $this;
     }

--- a/tests/PhoneRuleValidatorTest.php
+++ b/tests/PhoneRuleValidatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Propaganistas\LaravelPhone\Tests;
+
+use Illuminate\Validation\Validator;
+use libphonenumber\PhoneNumberType;
+use Propaganistas\LaravelPhone\Rules\Phone;
+
+class PhoneRuleValidatorTest extends TestCase
+{
+    protected function validate(array $data, array $rules): Validator
+    {
+        return $this->app['validator']->make($data, $rules);
+    }
+
+    /** @test */
+    public function it_validates_type()
+    {
+        $this->assertTrue($this->validate(
+            ['field' => '+32470123456'],
+            ['field' => (new Phone)->type(PhoneNumberType::MOBILE)]
+        )->passes());
+
+        $this->assertFalse($this->validate(
+            ['field' => '+3212345678'],
+            ['field' => (new Phone)->type(PhoneNumberType::MOBILE)]
+        )->passes());
+    }
+
+    /** @test */
+    public function it_validates_negative_type()
+    {
+        $this->assertFalse($this->validate(
+            ['field' => '+32470123456'],
+            ['field' => (new Phone)->notType(PhoneNumberType::MOBILE)]
+        )->passes());
+
+        $this->assertTrue($this->validate(
+            ['field' => '+3212345678'],
+            ['field' => (new Phone)->notType(PhoneNumberType::MOBILE)]
+        )->passes());
+    }
+}

--- a/tests/PhoneRuleValidatorTest.php
+++ b/tests/PhoneRuleValidatorTest.php
@@ -5,6 +5,7 @@ namespace Propaganistas\LaravelPhone\Tests;
 use Illuminate\Validation\Validator;
 use libphonenumber\PhoneNumberType;
 use Propaganistas\LaravelPhone\Rules\Phone;
+use Propaganistas\LaravelPhone\Exceptions\IncompatibleTypesException;
 
 class PhoneRuleValidatorTest extends TestCase
 {
@@ -39,5 +40,16 @@ class PhoneRuleValidatorTest extends TestCase
             ['field' => '+3212345678'],
             ['field' => (new Phone)->notType(PhoneNumberType::MOBILE)]
         )->passes());
+    }
+
+    /** @test */
+    public function it_doesnt_allow_type_and_not_type()
+    {
+        $this->expectException(IncompatibleTypesException::class);
+
+        $this->validate(
+            ['field' => '+3212345678'],
+            ['field' => (new Phone)->type(PhoneNumberType::MOBILE)->notType(PhoneNumberType::MOBILE)]
+        )->passes();
     }
 }


### PR DESCRIPTION
This extends the custom validation rule to allow you to specifically block certain phone number types, instead of just allowing certain types.

```php
(new Phone)->type(PhoneNumberType::MOBILE);
(new Phone)->notType(PhoneNumberType::MOBILE);
```

In some scenarios it makes more sense to block incompatible types rather than allow all the other possibilities.