### PR TITLE
feat: add support for laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.0, 8.1, 8.2, 8.3 ]
-        laravel: [ 9, 10 ]
+        laravel: [ 9, 10, 11 ]
         stability: [ prefer-lowest, prefer-stable ]
         exclude:
+          - php: 8.3
+            laravel: 9
           - php: 8.0
+            laravel: 10
+          - php: 8.0
+            laravel: 11
+          - php: 8.1
             laravel: 10
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (${{ matrix.stability }})
@@ -39,7 +45,7 @@ jobs:
         if: matrix.php == 8.2
         run: |
           composer require "nesbot/carbon=^2.63" --dev --no-interaction --no-update
-      
+
       - name: Install dependencies
         run: |
           composer require "illuminate/support=^${{ matrix.laravel }}" --no-interaction --no-update
@@ -47,6 +53,6 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
-        
+
       - name: Run phpstan
         run: vendor/bin/phpstan analyse --error-format=github

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
-        "illuminate/validation": "^9.0|^10.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/validation": "^9.0|^10.0|^11.0",
         "giggsey/libphonenumber-for-php": "^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "*",
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5.10|^10.5",
         "nunomaduro/larastan": "^2.4",
         "laravel/pint": "^1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "orchestra/testbench": "*",
         "phpunit/phpunit": "^9.5.10|^10.5",
-        "nunomaduro/larastan": "^2.4",
+        "larastan/larastan": "^2.8",
         "laravel/pint": "^1.4"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Adds support for Laravel 11 which will be released within a few weeks.

Maybe you also want to drop support for Laravel 9 and PHP 8.0 as both are EOL, however that would strictly be a breaking change.