### PR TITLE
Use libphonenumber-for-php-lite instead of libphonenumber-for-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/validation": "^10.0|^11.0",
-        "giggsey/libphonenumber-for-php": "^7.0|^8.0"
+        "giggsey/libphonenumber-for-php-lite": "^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/validation": "^10.0|^11.0",
-        "giggsey/libphonenumber-for-php-lite": "^8.13.1"
+        "giggsey/libphonenumber-for-php-lite": "^8.13.35"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/validation": "^10.0|^11.0",
-        "giggsey/libphonenumber-for-php-lite": "^8.0"
+        "giggsey/libphonenumber-for-php-lite": "^8.13.1"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -22,13 +22,13 @@ class PhoneNumber implements Jsonable, JsonSerializable
 {
     use Macroable;
 
-    protected ?string $number;
+    protected string $number;
 
     protected array $countries;
 
     protected bool $lenient = false;
 
-    public function __construct(?string $number, $country = [])
+    public function __construct(string $number, $country = [])
     {
         $this->number = $number;
         $this->countries = Arr::wrap($country);
@@ -244,7 +244,7 @@ class PhoneNumber implements Jsonable, JsonSerializable
         try {
             return $this->formatE164();
         } catch (Exception $e) {
-            return (string) $this->number;
+            return $this->number;
         }
     }
 }

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -22,15 +22,15 @@ class PhoneNumber implements Jsonable, JsonSerializable
 {
     use Macroable;
 
-    protected string $number;
+    protected ?string $number;
 
     protected array $countries;
 
     protected bool $lenient = false;
 
-    public function __construct(string $number, $country = [])
+    public function __construct(?string $number, $country = [])
     {
-        $this->number = $number;
+        $this->number = is_null($number) ? '': $number;
         $this->countries = Arr::wrap($country);
     }
 
@@ -244,7 +244,7 @@ class PhoneNumber implements Jsonable, JsonSerializable
         try {
             return $this->formatE164();
         } catch (Exception $e) {
-            return $this->number;
+            return (string) $this->number;
         }
     }
 }

--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -414,13 +414,6 @@ class PhoneNumberTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_empty_string_when_null_is_cast_to_string()
-    {
-        $object = new PhoneNumber(null);
-        $this->assertEquals('', (string) $object);
-    }
-
-    #[Test]
     public function it_gets_the_exceptions_number()
     {
         $exception = NumberParseException::countryRequired('12345');

--- a/tests/PhoneNumberTest.php
+++ b/tests/PhoneNumberTest.php
@@ -414,6 +414,13 @@ class PhoneNumberTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_empty_string_when_null_is_cast_to_string()
+    {
+        $object = new PhoneNumber(null);
+        $this->assertEquals('', (string) $object);
+    }
+
+    #[Test]
     public function it_gets_the_exceptions_number()
     {
         $exception = NumberParseException::countryRequired('12345');


### PR DESCRIPTION
This change allows to use `giggsey/libphonenumber-for-php-lite` instead of `giggsey/libphonenumber-for-php`.

`giggsey/libphonenumber-for-php-lite` is only 1.6MB in comparison with 19MB for `giggsey/libphonenumber-for-php`, allowing for a much smaller package size.

The main caveat is that only version 8.x of the library can be used, since the lite variant was created based on version 8 of the original library.
~It is also not possible to pass `null` as a phone number with the lite version, hence the test that I removed.~