### PR TITLE
Fix mb_strtoupper(): Passing null deprecated errors

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -81,7 +81,7 @@ class PhoneNumber implements Jsonable, JsonSerializable
 
         if ($instanceCountry !== null) {
             return in_array(
-                mb_strtoupper($instance->getCountry()),
+                mb_strtoupper($instanceCountry),
                 array_map('mb_strtoupper', $instance->countries)
             );
         }

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -76,11 +76,17 @@ class PhoneNumber implements Jsonable, JsonSerializable
     {
         $instance = clone $this;
         $instance->countries = Arr::wrap($country);
+        
+        $instanceCountry = $instance->getCountry();
 
-        return in_array(
-            mb_strtoupper($instance->getCountry()),
-            array_map('mb_strtoupper', $instance->countries)
-        );
+        if ($instanceCountry !== null) {
+            return in_array(
+                mb_strtoupper($instance->getCountry()),
+                array_map('mb_strtoupper', $instance->countries)
+            );
+        }
+
+        return false;
     }
 
     public static function isValidCountry(string $country): bool

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -79,14 +79,14 @@ class PhoneNumber implements Jsonable, JsonSerializable
         
         $instanceCountry = $instance->getCountry();
 
-        if ($instanceCountry !== null) {
-            return in_array(
-                mb_strtoupper($instanceCountry),
-                array_map('mb_strtoupper', $instance->countries)
-            );
+        if ($instanceCountry === null) {
+            return false;
         }
 
-        return false;
+        return in_array(
+            mb_strtoupper($instanceCountry),
+            array_map('mb_strtoupper', $instance->countries)
+        );
     }
 
     public static function isValidCountry(string $country): bool


### PR DESCRIPTION
Sentry keep notifying me thousands of times of a deprecation error (I'm using PHP 8.4 & Laravel 12 if it helps).

Here are my validation rules for my mobile_phone field

```php
[
    'required',
    Rule::phone()->country('SG')->mobile()
]
```

Which looks completely correct to me, the code works fine too but I just keep getting these deprecation alerts in Sentry. So I came to the conclusion that this likely best way to fix those deprecation alerts

Hope you can merge it, thank you